### PR TITLE
Fixed typo

### DIFF
--- a/app.json
+++ b/app.json
@@ -617,7 +617,7 @@
         "id": "SP200689103:received",
         "title": {
           "en": "Doorbell is pressed",
-          "nl": "Doorbell gaat af"
+          "nl": "Deurbel gaat af"
         },
         "args": [
           {


### PR DESCRIPTION
NL text in trigger corrected from 'Doorbell' to 'Deurbel'